### PR TITLE
Added the missing "customClass" option to the message-box component

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
-build
+#build
 tests
-site
+#site
 .*

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
 #build
 tests
-#site
+site
 .*

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
-#build
+build
 tests
 site
 .*

--- a/src/message-box/MessageBox.jsx
+++ b/src/message-box/MessageBox.jsx
@@ -122,7 +122,7 @@ export default class MessageBox extends Component {
   }
 
   render(): React.Element<any> {
-    const { willUnmount, title, showClose, message, showInput, inputPlaceholder, showCancelButton, cancelButtonClass, showConfirmButton, confirmButtonClass, inputType } = this.props;
+    const { willUnmount, title, showClose, message, showInput, inputPlaceholder, showCancelButton, cancelButtonClass, showConfirmButton, confirmButtonClass, customClass, inputType } = this.props;
     const { visible, editorErrorMessage } = this.state;
 
     return (
@@ -133,7 +133,7 @@ export default class MessageBox extends Component {
             onAfterLeave={() => { willUnmount && willUnmount() }}
           >
             <View show={visible}>
-              <div className="el-message-box__wrapper">
+              <div className={this.classNames('el-message-box__wrapper', customClass)}>
                 <div className="el-message-box">
                   {
                     title && (
@@ -211,6 +211,7 @@ MessageBox.propTypes = {
   cancelButtonText: PropTypes.string,
   cancelButtonClass: PropTypes.string,
   confirmButtonClass: PropTypes.string,
+  customClass: PropTypes.string,
   inputPlaceholder: PropTypes.string,
   inputPattern: PropTypes.regex,
   inputValidator: PropTypes.func,


### PR DESCRIPTION
* [X] Make sure you are merging your commits to `master` branch.
* [X] Add some descriptions and refer relative issues for you PR.
* [X] Rebase your commits to make your pull request meaningful.
* [X] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

- Added the missing "customClass" to the message-box component. The documentation for MessageBox shows the availability for a customClass option, however the code does not. We have added the option back in and attached it to the component wrapper for use. 
- https://elemefe.github.io/element-react/#/en-US/message-box
