### PR TITLE
[AnchorSmooth,GoTop]:添加两个锚点相关的功能，以及中英文版的使用说明markdown文档。功能如下： 

### DIFF
--- a/site/docs/en-US/anchor-smooth.md
+++ b/site/docs/en-US/anchor-smooth.md
@@ -1,0 +1,86 @@
+## AnchorSmooth 
+
+A label slide to anchor point.
+
+### Basic usage
+
+Similar to the use of a tag, the attribute targetId is used to indicate the anchor that you want to reach.
+
+::: demo The AnchorSmooth component provides `targetId` attributes to point to ID elements that exist in the page and must have values. If the child element does not exist, `targetId` is used as the child element.
+```js
+render() {
+  return (
+    <div>
+      <div className='anchor-point' id='anchor0'>Here is the anchor#anchor0</div>
+      <div className='anchor-group'>
+          <AnchorSmooth targetId='anchor1' />
+          <AnchorSmooth targetId='anchor1'>
+      		Slide to anchor#anchor1
+      	  </AnchorSmooth>
+      </div>
+    </div>
+  )
+}
+```
+:::
+
+### callback
+
+The attribute `onFinish` can bind a callback function and execute the callback function after reaching the anchor point.
+
+::: demo In the AnchorSmooth component, you can set the `onFinish` callback function that completes the sliding, and then call the `onFinish` function when it reaches the anchor.
+```js
+render() {
+  return (
+    <div>
+      <div id='anchor1' className='anchor-point'>
+      	  Here is the anchor#anchor1
+      </div>
+      <AnchorSmooth 
+          targetId='anchor2' 
+          onFinish={() => console.log("Arrive at anchor2")}>
+          Go to the anchor with ID anchor2 and execute the callback function
+	  </AnchorSmooth>
+    </div>
+  )
+}
+```
+:::
+
+### set title
+
+The` title` property tells the user the anchor to go when the mouse moves in.
+
+::: demo Use the `title` attribute to describe an anchor.
+```js
+render() {
+  return (
+    <div>
+      <div id='anchor2' className='anchor-point'>
+      	 Here is the anchor#anchor2
+      </div>
+      <AnchorSmooth 
+          targetId='anchor0' 
+          title="go to anchor0" 
+          onFinish={() => console.log("Arrive at anchor0")}>
+      	To the anchor with ID anchor0, containing title
+	  </AnchorSmooth>
+    </div>
+  )
+}
+```
+:::
+
+### Attributes
+
+| Attribute | Description | Type  | Accepted Values            | Default |
+|---------- |-------------- |---------- |--------------------------------  |-------- |
+| **targetId** | Anchor target   **REQUIRED** | string | — | — |
+| title | title | string | — | — |
+
+### Events
+
+| Event Name | Description | Parameters |
+|---------- |-------- |---------- |
+| onFinish | fires when anchor is arrived | — |
+

--- a/site/docs/en-US/go-top.md
+++ b/site/docs/en-US/go-top.md
@@ -1,0 +1,120 @@
+## GoTop
+
+In a long page, you can go back to the top of the page by clicking on the button from the bottom to the top.
+
+### Basic usage
+
+Usually the top-back button appears in the lower right corner of the page, so it is recommended to modify the `right`, `bottom` attributes for positioning; if there are special needs, you can also modify the `left`, `top` attributes.
+
+::: demo In the GoTop component, you can modify the `right` and `bottom` attributes with the default values of right: 50px and bottom: 50px.
+```js
+render() {
+  return (
+    <div>
+      <h3>Basic usage: The first button in the lower right corner</h3>
+      <GoTop bottom="360px" showheight={0}/>
+    </div>
+  )
+}
+```
+:::
+
+### Property `showheight`
+
+Usually the top button will not appear when the rolling distance is 0. We can define the height of the scrollbar when the button appears by the attribute `showheight`, with the default value of 300, per unit px. If the scroll distance is greater than 300, the display button will fade in; if the scroll distance is less than 300, the hidden button will fade out.
+
+::: demo In the GoTop component, you can modify the showheight property to specify the scroll distance of the scrollbar, default value: 300; type: number.
+
+```js
+render() {
+  return (
+    <div>
+      <h3>
+          A button appears when the scroll distance is 200 px: 
+          the second button in the lower right corner
+      </h3>
+      <GoTop bottom="300px" showheight={200}/>
+    </div>
+  )
+}
+```
+
+:::
+
+### With icon
+
+By default, the `el-icon-caret-top` in elementUI can be used to replace the default icon by setting sub-elements.
+
+::: demo By setting the` children` attribute to display GoTop's icon, you can more effectively show the user your display intentions.
+```js
+render() {
+  return (
+    <div>
+      <h3>With icon：The third button in the lower right corner</h3>
+      <GoTop bottom="240px">
+      	<i className="el-icon-arrow-up"></i>
+      </GoTop>
+    </div>
+  )
+}
+```
+:::
+
+### Sliding time and callback function
+
+Customize the time used to complete the sliding, attribute: `time`, default value: 300, unit: Ms.
+
+::: demo In the GoTop component, you can set the `time` needed to complete the sliding and call an `onFinish` callback function when you reach the anchor.
+
+```js
+render() {
+  return (
+    <div>
+      <h3>
+      	Custom sliding time and callback function:
+      	The fourth button in the lower right corner
+      </h3>
+      <GoTop bottom="180px" time={800} 
+      	onFinish={() => console.log("go to top")}/>
+    </div>
+  )
+}
+```
+
+:::
+
+### Set title
+
+The` title` property tells the user the anchor to go when the mouse moves in.
+
+::: demo Use the `title` attribute to describe an anchor.
+
+```js
+render() {
+  return (
+    <div>
+      <h3>Title: the fifth button in the lower right corner</h3>
+      <GoTop bottom="120px" title="go to top" />
+    </div>
+  )
+}
+```
+
+:::
+
+### Attributes
+| Attribute | Description | Type  | Accepted Values            | Default |
+|---------- |-------------- |---------- |--------------------------------  |-------- |
+| showheight | Scrollbar Scroll Distance Threshold, Unit PX | number | — | 300 |
+| time | The time required to reach the top, unit MS | number | — | 300 |
+| title | title | string | — | — |
+| right | Distance to the rightof the page | string | — | 50px |
+| bottom | Distance to the bottom of the page | string | — | 50px |
+| top | Distance to the top of the page | string | — | — |
+| left | Distance to the left of the page | string | — | — |
+
+### Events
+
+| Event Name | Description                  | Parameters |
+| ---------- | ---------------------------- | ---------- |
+| onFinish   | fires when anchor is arrived | —          |

--- a/site/docs/zh-CN/anchor-smooth.md
+++ b/site/docs/zh-CN/anchor-smooth.md
@@ -1,0 +1,85 @@
+## AnchorSmooth 滑向锚点
+
+用于a标签滑向锚点。
+
+### 基本用法
+
+和a标签用法类似，使用属性`targetId`表明想到达的锚点。
+
+::: demo AnchorSmooth 组件提供`targetId`属性指向页面中**存在id元素**，必须值。若子元素不存在，则使用`targetId`当作子元素。
+```js
+render() {
+  return (
+    <div>
+      <div className='anchor-point' id='anchor0'>这里是锚点#anchor0</div>
+      <div className='anchor-group'>
+          <AnchorSmooth targetId='anchor1' />
+          <AnchorSmooth targetId='anchor1'>
+      		滑动到锚点anchor1
+      	  </AnchorSmooth>
+      </div>
+    </div>
+  )
+}
+```
+:::
+
+### 回调函数
+
+属性`onFinish`可在绑定一个回调函数，在到达锚点后执行回调函数。
+
+::: demo 在 AnchorSmooth 组件中，你可以设置完成滑动完成的回调函数`onFinish`，到达锚点之后会调用`onFinish`函数。
+```js
+render() {
+  return (
+    <div>
+      <div id='anchor1' className='anchor-point'>
+      	  这里是锚点#anchor1
+      </div>
+      <AnchorSmooth 
+          targetId='anchor2' 
+          onFinish={() => console.log("Arrive at anchor2")}>
+          到id为anchor2的锚点，并执行回调函数
+	  </AnchorSmooth>
+    </div>
+  )
+}
+```
+:::
+
+### 设置标题
+
+`title`属性，鼠标移入时告诉用户即将去的锚点。
+
+::: demo 使用`title`属性来描述一个锚点。
+```js
+render() {
+  return (
+    <div>
+      <div id='anchor2' className='anchor-point'>
+      	 这里是锚点#anchor2
+      </div>
+      <AnchorSmooth 
+          targetId='anchor0' 
+          title="go to anchor0" 
+          onFinish={() => console.log("Arrive at anchor0")}>
+      	到id为anchor0的锚点，包含title
+	  </AnchorSmooth>
+    </div>
+  )
+}
+```
+:::
+
+### Attributes
+
+| 参数      | 说明          | 类型      | 可选值                           | 默认值  |
+|---------- |-------------- |---------- |--------------------------------  |-------- |
+| **targetId** | 锚点目标，页面中需要有对应id，**必选参数** | string | — | — |
+| title | 辅助性文字 | string | — | — |
+
+### Events
+
+| 事件名称 | 说明 | 回调参数 |
+|---------- |-------- |---------- |
+| onFinish | 锚点到达时的回调函数 | — |

--- a/site/docs/zh-CN/go-top.md
+++ b/site/docs/zh-CN/go-top.md
@@ -1,0 +1,114 @@
+## GoTop 回顶部
+
+长页面中从底部回到顶部的按钮，点击可以回到页面顶部。
+
+### 基本用法
+
+通常回顶部按钮出现在页面的右下角，因此建议修改`right`，`bottom`属性进行定位；若有特殊需求，也可以修改`left` ，`top`属性。
+
+::: demo 在 GoTop组件中，你可以修改`right`，`bottom`属性，默认值为right:50px;bottom:50px;。
+```js
+render() {
+  return (
+    <div>
+      <h3>基本用法：右下角按钮第一个</h3>
+      <GoTop bottom="360px" showheight={0}/>
+    </div>
+  )
+}
+```
+:::
+
+### 出现时机
+
+一般回顶部按钮，不会在滚动距离为0时出现。我们可以通过属性`showheight` 来定义按钮出现时滚动条的高度，默认值为300，单位px。滚动距离大于300，会淡入显示按钮；小于300，会淡出隐藏按钮。
+
+::: demo 在 GoTop组件中，你可以修改`showheight`属性，指定滚动条的滚动距离，默认值：300;类型：number。
+
+```js
+render() {
+  return (
+    <div>
+      <h3>在滚动距离为200px时出现按钮：右下角按钮第二个</h3>
+      <GoTop bottom="300px" showheight={200}/>
+    </div>
+  )
+}
+```
+
+:::
+
+### 替换 icon
+
+GoTop 组件中，默认使用elementUI中的el-icon-caret-top，可以通过设置子元素的方式，替换默认icon图标。
+
+::: demo 通过设置`children`属性来显示 GoTop 的 icon，这能更有效地向用户展示你的显示意图。
+```js
+render() {
+  return (
+    <div>
+      <h3>替换 icon：右下角按钮第三个</h3>
+      <GoTop bottom="240px">
+      	<i className="el-icon-arrow-up"></i>
+      </GoTop>
+    </div>
+  )
+}
+```
+:::
+
+### 滑动时间和回调函数
+
+自定义完成滑动所用的时间，属性:` time`，默认值: 300，单位: ms。
+
+::: demo 在 GoTop 组件中，你可以设置完成滑动所用的时间`time`，到达锚点之后会调用一个的`onFinish`的回调函数。`time`属性决定完成滑动所用的时间，接受`number`，默认为300。
+
+```js
+render() {
+  return (
+    <div>
+      <h3>自定义滑动时间和回调函数：右下角按钮第四个</h3>
+      <GoTop bottom="180px" time={800} 
+      	onFinish={() => console.log("go to top")}/>
+    </div>
+  )
+}
+```
+
+:::
+
+### title
+
+包含标题，鼠标移入时告诉用户即将去的锚点。
+
+::: demo 使用`title`属性来描述一个锚点。
+
+```js
+render() {
+  return (
+    <div>
+      <h3>title：右下角按钮第五个</h3>
+      <GoTop bottom="120px" title="go to top" />
+    </div>
+  )
+}
+```
+
+:::
+
+### Attributes
+| 参数      | 说明          | 类型      | 可选值                           | 默认值  |
+|---------- |-------------- |---------- |--------------------------------  |-------- |
+| showheight | 滚动条滚动距离阈值，单位px | number | — | 300 |
+| time | 到达描点所需要的时间，单位ms | number | — | 300 |
+| title | title | string | — | — |
+| right | 到页面右边的距离 | string | — | 50px |
+| bottom | 到页面底端的距离 | string | — | 50px |
+| top | 到页面顶端的距离 | string | — | — |
+| left | 到页面左边的距离 | string | — | — |
+
+### Events
+
+| 事件名称 | 说明                       | 回调参数 |
+| -------- | -------------------------- | -------- |
+| onFinish | 滚动条到达顶部时的回调函数 | —        |

--- a/site/locales/en-US.js
+++ b/site/locales/en-US.js
@@ -45,7 +45,9 @@ module.exports = {
     'popover': 'Popover',
     'card': 'Card',
     'carousel': 'Carousel',
-    'collapse': 'Collapse'
+    'collapse': 'Collapse',
+    'anchor-smooth':'AnchorSmooth',
+    'go-top':'GoTop'
   },
   misc: {
     'guide': 'Guide',

--- a/site/locales/zh-CN.js
+++ b/site/locales/zh-CN.js
@@ -45,7 +45,9 @@ module.exports = {
     'popover': 'Popover 弹出框',
     'card': 'Card 卡片',
     'carousel': 'Carousel 走马灯',
-    'collapse': 'Collapse 折叠面板'
+    'collapse': 'Collapse 折叠面板',
+    'anchor-smooth':'AnchorSmooth 滑向锚点',
+    'go-top':'GoTop 回顶部'
   },
   misc: {
     'guide': '指南',

--- a/site/pages/anchor-smooth/index.jsx
+++ b/site/pages/anchor-smooth/index.jsx
@@ -1,0 +1,9 @@
+import Markdown from '../../../libs/markdown';
+
+import './style.scss';
+
+export default class AnchorSmooth extends Markdown {
+  document(locale) {
+    return require(`../../docs/${locale}/anchor-smooth.md`);
+  }
+}

--- a/site/pages/anchor-smooth/style.scss
+++ b/site/pages/anchor-smooth/style.scss
@@ -1,0 +1,13 @@
+.demo-anchorsmooth{
+
+  .anchor-point{
+    color: #20a0ff;
+    height: 50px;
+    line-height: 50px;
+  }
+
+  .anchor-group a{
+    margin-right: 100px;
+  }
+
+}

--- a/site/pages/go-top/index.jsx
+++ b/site/pages/go-top/index.jsx
@@ -1,0 +1,9 @@
+import Markdown from '../../../libs/markdown';
+
+import './style.scss';
+
+export default class GoTop extends Markdown {
+  document(locale) {
+    return require(`../../docs/${locale}/go-top.md`);
+  }
+}

--- a/site/pages/go-top/style.scss
+++ b/site/pages/go-top/style.scss
@@ -1,0 +1,5 @@
+.demo-gotop {
+  h3{
+    color: #20a0ff;
+  }
+}

--- a/site/pages/index.jsx
+++ b/site/pages/index.jsx
@@ -58,7 +58,9 @@ export default {
       'popover': require('./popover'),
       'card': require('./card'),
       'carousel': require('./carousel'),
-      'collapse': require('./collapse')
+      'collapse': require('./collapse'),
+      'anchor-smooth':require('./anchor-smooth'),
+      'go-top':require('./go-top')
     }
   }
 }

--- a/src/anchor/AnchorSmooth.jsx
+++ b/src/anchor/AnchorSmooth.jsx
@@ -1,0 +1,91 @@
+/* @flow */
+
+import React from 'react';
+import {Component, PropTypes} from '../../libs';
+
+
+const doNothing = () => undefined;
+
+function goTarget(targetTop, time = 300, callback = doNothing) {
+  let interval = 10;
+  time = Math.max(time, 100);
+  let initTop = document.documentElement.scrollTop || document.body.scrollTop;
+  let total = Math.ceil(time / interval);
+  let speed = (targetTop - initTop) / total;
+  let timer = null;
+  let count = 1;
+
+  if (speed === 0) {
+    return;
+  }
+
+  function goMove() {
+    if (count >= total) {
+      window.scrollTo(0, targetTop);
+      clearInterval(timer);
+      callback && callback();
+      return;
+    }
+    window.scrollTo(0, speed * count + initTop);
+    count++;
+  }
+
+  timer = setInterval(goMove, interval);
+}
+
+export default class AnchorSmooth extends Component {
+  constructor() {
+    super(...arguments);
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick(e) {
+    e.preventDefault();
+    let targetDom = document.getElementById(this.props.targetId);
+    if(targetDom && targetDom.scrollIntoView){
+      targetDom.scrollIntoView({
+        behavior:'smooth',
+        block:'start',
+        inline:'nearest'
+      });
+      this.props.onFinish && this.props.onFinish();
+    }else{
+      let targetTop = targetDom ? targetDom.offsetTop : 0;
+      goTarget(targetTop, this.props.time,this.props.onFinish);
+    }
+  }
+
+
+  shouldComponentUpdate(nextProps) {
+    for (let key of Object.keys(nextProps)) {
+      if (nextProps[key] !== this.props[key]) {
+        return true;
+      }
+    }
+    for (let key of Object.keys(this.props)) {
+      if (this.props[key] !== nextProps[key]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  render() {
+    const {targetId, children, ...other} = this.props;
+    return (
+      <a {...other} href={targetId ? "#" + targetId : ""}  onClick={this.onClick}
+      >{children || targetId}</a>
+    )
+  }
+}
+
+AnchorSmooth.propTypes = {
+  targetId: PropTypes.string,
+  time: PropTypes.number,
+  onFinish:PropTypes.func
+};
+
+AnchorSmooth.defaultProps = {
+  time: 300
+};
+

--- a/src/anchor/GoTop.jsx
+++ b/src/anchor/GoTop.jsx
@@ -1,0 +1,66 @@
+/* @flow */
+
+import React from 'react';
+import {Component,PropTypes} from '../../libs';
+import AnchorSmooth from './AnchorSmooth';
+import './style.css';
+
+export default class GoTop extends Component {
+
+  constructor() {
+    super(...arguments);
+    this.state = {show: false};
+    this.showAnchor = this.showAnchor.bind(this);
+  }
+
+  showAnchor() {
+    let scrollY = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop;
+    let show = scrollY >= this.props.showheight;
+    if (this.state.show !== show) {
+      this.setState({
+        show
+      });
+    }
+  }
+
+  componentDidMount() {
+    this.showAnchor();
+    window.addEventListener("scroll", this.showAnchor)
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("scroll", this.showAnchor);
+  }
+
+  render() {
+    const {children,bottom, right, top, left, ...other} = this.props;
+    return (
+      <div className="el-anchor__top-wrapper" style={{
+        bottom,
+        right,
+        top,
+        left,
+        opacity: this.state.show ? "1" : "0",
+        visibility: this.state.show ? "visible" : "hidden",
+        transition: this.state.show ? "opacity 0.2s linear 0s, visibility" : ""
+      }}>
+        <AnchorSmooth className='el-anchor__top'
+          {...other}>
+          {children || <i className="el-icon-caret-top"></i>}
+        </AnchorSmooth>
+      </div>
+    )
+  }
+}
+
+GoTop.propTypes = {
+  showheight:PropTypes.number,
+  bottom:PropTypes.string,
+  top:PropTypes.string,
+  left:PropTypes.string,
+  right:PropTypes.string
+};
+
+GoTop.defaultProps = {
+  showheight:300
+};

--- a/src/anchor/index.js
+++ b/src/anchor/index.js
@@ -1,0 +1,4 @@
+import AnchorSmooth from './AnchorSmooth';
+import GoTop from './GoTop';
+
+export {AnchorSmooth,GoTop};

--- a/src/anchor/style.css
+++ b/src/anchor/style.css
@@ -1,0 +1,28 @@
+.el-anchor__top-wrapper {
+  position: fixed;
+  bottom: 50px;
+  right: 50px;
+  z-index: 99;
+  transition: opacity 0.2s linear 0s, visibility 0s linear 0.2s;
+}
+
+.el-anchor__top {
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  background-color: #58b7ff;
+  display: block;
+  text-align: center;
+  line-height: 50px;
+  opacity: 0.4;
+  transition: opacity 0.3s linear 0s;
+}
+
+.el-anchor__top:hover {
+  opacity: 1;
+}
+
+.el-anchor__top i {
+  color: #ffffff;
+  font-size: 22px;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export { default as i18n } from './locale';
 
 export { default as Alert } from './alert';
+export { AnchorSmooth, GoTop} from './anchor';
 export { default as Button } from './button';
 export { default as Card } from './card';
 export { default as Layout } from './layout';


### PR DESCRIPTION

1.AnchorSmooth：实现点击AnchorSmooth滑动到相应的锚点，而不是直接跳转；
2.GoTop：可以定制的回顶部功能按钮，包括按钮的出现时间，回到顶部时执行的回调函数。 
*问题：GoTop组件需要的一些样式，直接放在了anchor目录下，没有做成默认样式，供用户选择。
*说明：看过pr指南，并全部通过，才提交pr的。

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] Rebase your commits to make your pull request meaningful.
* [x] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

- 添加两个锚点相关的功能:1.AnchorSmooth：实现点击AnchorSmooth滑动到相应的锚点，而不是直接跳转；2.GoTop：可以定制的回顶部功能按钮，包括按钮的出现时间，回到顶部时执行的回调函数。
- 以及中英文版的markdown文档使用说明，包括：en-US/anchor-smooth.md文件；en-US/go-top.md文件；zh-CN/anchor-smooth.md文件；zh-CN/anchor-smooth.md文件；
- 文件命名合理，并通过 `npm test`, `npm run lint` and `npm run build`命令测试。
- 对已有功能未做任何修改。
