### PR TITLE
Popover: Prevent hide if already hidden. Fix #1027

### DIFF
--- a/src/popover/Popover.jsx
+++ b/src/popover/Popover.jsx
@@ -44,7 +44,7 @@ export default class Popover extends Component {
       });
 
       document.addEventListener('click', (e: Event): void => {
-        if (!this.element || this.element.contains(e.target) ||
+        if (!this.state.showPopper || !this.element || this.element.contains(e.target) ||
             !this.reference || this.reference.contains(e.target) ||
             !popper || popper.contains(e.target)) return;
 
@@ -128,7 +128,7 @@ export default class Popover extends Component {
             <div ref="popper" className={this.className('el-popover', popperClass)} style={this.style({ width: Number(width) })}>
               { title && <div className="el-popover__title">{title}</div> }
               { content }
-              { visibleArrow && <div ref="arrow" className="popper__arrow"/>}
+              { visibleArrow && <div ref="arrow" className="popper__arrow" />}
             </div>
           </View>
         </Transition>


### PR DESCRIPTION
Prevents unnecessary re-renders of all hidden popovers in the page.

* [x] Make sure you are merging your commits to `master` branch.
* [x] Add some descriptions and refer relative issues for you PR.
* [x] Rebase your commits to make your pull request meaningful.
* [ ] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Edit: My changes do not affect the failing tests, however the current master branch is already broken, I can rebase once fixed.

Changes in this pull request
Fixes #1027 
- Prevents click outside setting state to false if showPopper is already false.
